### PR TITLE
Pass :only option to sprinkle script

### DIFF
--- a/lib/vagrant-sprinkle/provisioner.rb
+++ b/lib/vagrant-sprinkle/provisioner.rb
@@ -16,7 +16,7 @@ module VagrantPlugins
       def compile_options
         options = []
         options << "--script=#{config.script}"
-        options << "--only #{config.only}" if config.only
+        options << "--only=#{config.only}" if config.only
         options << '--test' if config.test
         options << '--verbose' if config.verbose
         options << '--cloud' if config.cloud

--- a/lib/vagrant-sprinkle/version.rb
+++ b/lib/vagrant-sprinkle/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Sprinkle
-    VERSION = "0.0.2"
+    VERSION = "0.0.3"
   end
 end


### PR DESCRIPTION
Fixes issue where :only option raised an error when used in Vagrantfile.

Fixes #1
